### PR TITLE
Some fixes.

### DIFF
--- a/debreach/context_processors.py
+++ b/debreach/context_processors.py
@@ -27,7 +27,7 @@ def csrf(request):
             aes = AES.new(key)
             padding = ''.join(' ' for x in range(16 - (len(token) % 16)))
             value = base64.encodestring(
-                aes.encrypt('{0}{1}'.format(token, padding)))
+                aes.encrypt('{0}{1}'.format(token, padding))).strip()
             token = '$'.join((key, value))
             return smart_text(token)
     _get_val = lazy(_get_val, text_type)

--- a/debreach/middleware.py
+++ b/debreach/middleware.py
@@ -23,7 +23,6 @@ class CSRFCryptMiddleware(object):
                 POST = request.POST.copy()
                 token = POST.get('csrfmiddlewaretoken')
                 key, value = token.split('$')
-                key = base64.decodestring(force_bytes(key)).strip()
                 value = base64.decodestring(force_bytes(value)).strip()
                 aes = AES.new(key)
                 POST['csrfmiddlewaretoken'] = aes.decrypt(value).strip()


### PR DESCRIPTION
The key does not need to be decoded before decrypting - it was used in base64encoded form for encryption.

I stripped a stray newline from the outgoing token.

This version now works with my Django 1.4.5.
