### PR TITLE
Fixing setup on Windows: setup fails because of an unsupported absolute path in the MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,1 @@
-include requirements.txt setup.py
-recursive-exclude / *.pyc
+include requirements.txt setup.py LICENSE


### PR DESCRIPTION
Adding also the LICENSE file to the manifest
Without this, installation fails on Windows. With this fix install works fine on posix and windows
