### PR TITLE
Fix TypeError in RandomCommentMiddleware

### DIFF
--- a/debreach/compat.py
+++ b/debreach/compat.py
@@ -11,7 +11,7 @@ except ImportError:  # pragma: no cover
     from django.utils.encoding import (                         # NOQA
         smart_unicode as smart_text, smart_str as force_bytes)  # NOQA
     force_text = smart_text
-    string_types = basestring
+    string_types = (basestring,)
     text_type = unicode
     binary_type = str
 

--- a/debreach/tests.py
+++ b/debreach/tests.py
@@ -201,7 +201,7 @@ class IntegrationTests(TestCase):
             request.META['CSRF_COOKIE'] = csrf_token
             token = force_text(csrf(request)['csrf_token'])
             request = RequestFactory().post(
-                '/', {'csrfmiddlewaretoken': token})
+                '/', {'csrfmiddlewaretoken': token[:]})
             middleware = CSRFCryptMiddleware()
             middleware.process_request(request)
             self.assertEqual(


### PR DESCRIPTION
I'm using django 1.4.1 on python 2.6 on CentOS 5.8.

Trying to load pages with the random comment middleware gives you the following error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.6/site-packages/Django-1.4.1-py2.6.egg/django/contrib/staticfiles/handlers.py", line 67, in __call__
    return self.application(environ, start_response)
  File "/usr/local/lib/python2.6/site-packages/Django-1.4.1-py2.6.egg/django/core/handlers/wsgi.py", line 241, in __call__
    response = self.get_response(request)
  File "/usr/local/lib/python2.6/site-packages/Django-1.4.1-py2.6.egg/django/core/handlers/base.py", line 192, in get_response
    response = self.handle_uncaught_exception(request, resolver, sys.exc_info())
  File "/usr/local/lib/python2.6/site-packages/Django-1.4.1-py2.6.egg/django/core/handlers/base.py", line 221, in handle_uncaught_exception
    return debug.technical_500_response(request, *exc_info)
  File "/usr/local/lib/python2.6/site-packages/Django-1.4.1-py2.6.egg/django/core/handlers/base.py", line 188, in get_response
    response = middleware_method(request, response)
  File "/usr/local/lib/python2.6/site-packages/debreach/middleware.py", line 59, in process_response
    str_types = string_types + (binary_type,)
TypeError: unsupported operand type(s) for +: 'type' and 'tuple'
```

This is because the `string_types` imported from `compat.py` is not a tuple. Changing this to a tuple fixes this issue and passes the tests.

However, I was getting issues with `test_round_trip_loop` when running the tests. Forcing the token (which was a django functional proxy object) to a string fixes this problem. This isn't an issue when running a django app.
