### PR TITLE
Include runtests.py in sdist tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include README.rst
+include runtests.py
 recursive-include debreach *.html *.png *.gif *js *jpg *jpeg *svg *py
 recursive-include docs *.rst *.py make.bat Makefile
 recursive-include test_project *.py *.html


### PR DESCRIPTION
When packaging the project, we cannot run unit tests unless the
runtests.py file is available.