### PR TITLE
Replace distutils

### DIFF
--- a/debreach/__init__.py
+++ b/debreach/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from distutils import version
+import packaging.version
 
 
 __version__ = '2.1.0'
-version_info = version.StrictVersion(__version__).version
+version_info = packaging.version.Version(__version__).release
 
 default_app_config = 'debreach.apps.DebreachConfig'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 django>=1.3
+packaging


### PR DESCRIPTION
distutils was deprecated in Python 3.10, and was removed from core Python in Python 3.12 .