### PR TITLE
Remove coding header

### DIFF
--- a/debreach/__init__.py
+++ b/debreach/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import packaging.version
 
 

--- a/debreach/apps.py
+++ b/debreach/apps.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from django.apps import AppConfig
 
 

--- a/debreach/decorators.py
+++ b/debreach/decorators.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from functools import wraps
 
 from django.utils.decorators import decorator_from_middleware

--- a/debreach/middleware.py
+++ b/debreach/middleware.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 import random
 

--- a/debreach/tests.py
+++ b/debreach/tests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import unittest
 


### PR DESCRIPTION
In Python 3 all source codes are considered to use utf-8 by default, so explicit definition is no longer needed.