### PR TITLE
Update supported python/django versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,15 +16,15 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Framework :: Django
-    Framework :: Django :: 2.2
-    Framework :: Django :: 3.2
-    Framework :: Django :: 4.0
+    Framework :: Django :: 4.2
+    Framework :: Django :: 5.2
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Internet :: WWW/HTTP
@@ -34,7 +34,7 @@ zip_safe = False
 include_package_data = True
 packages = find:
 setup_requires = setuptools;wheel;pip
-python_requires = >=3.7
+python_requires = >=3.9
 tests_require = django
 
 [options.packages.find]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39}-dj{22,32}, py{38,39,310}-dj40, pypy3-dj{22,32}, docs
+envlist = py{39,310,311,312,313}-dj42,py{310,311,312,313}-dj52, docs
 skip_missing_interpreters = True
 isolated_build = True
 
@@ -7,9 +7,9 @@ isolated_build = True
 PYTHONPATH = {toxinidir}:{toxinidir}/debreach
 commands = python runtests.py
 deps =
-    dj40: django>=4.0,<4.1
-    dj22: django>=2.2,<3.0
-    dj32: django>=3.2,<4.0
+    -r requirements.txt
+    dj52: django>=5.2,<5.3
+    dj42: django>=4.2,<4.3
 
 [testenv:docs]
 changedir = docs


### PR DESCRIPTION
Drop supported for unmaintained python/django versions.

Also add recent python/django versions to supported list.