### PR TITLE
Fix docs generation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,14 +49,14 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'django-debreach'
-copyright = u'2013, Luke Pomfrey'
+project = 'django-debreach'
+copyright = '2013, Luke Pomfrey'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-version = u'{0}'.format(version.Version(version_string))
+version = '{0}'.format(version.Version(version_string))
 # The full version, including alpha/beta/rc tags.
 release = version_string
 
@@ -191,8 +191,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'django-debreach.tex', u'django-debreach Documentation',
-   u'Luke Pomfrey', 'manual'),
+  ('index', 'django-debreach.tex', 'django-debreach Documentation',
+   'Luke Pomfrey', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -221,8 +221,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'django-debreach', u'django-debreach Documentation',
-     [u'Luke Pomfrey'], 1)
+    ('index', 'django-debreach', 'django-debreach Documentation',
+     ['Luke Pomfrey'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -235,8 +235,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'django-debreach', u'django-debreach Documentation',
-   u'Luke Pomfrey', 'django-debreach', 'One line description of project.',
+  ('index', 'django-debreach', 'django-debreach Documentation',
+   'Luke Pomfrey', 'django-debreach', 'One line description of project.',
    'Miscellaneous'),
 ]
 
@@ -253,10 +253,10 @@ texinfo_documents = [
 # -- Options for Epub output ---------------------------------------------------
 
 # Bibliographic Dublin Core info.
-epub_title = u'django-debreach'
-epub_author = u'Luke Pomfrey'
-epub_publisher = u'Luke Pomfrey'
-epub_copyright = u'2013, Luke Pomfrey'
+epub_title = 'django-debreach'
+epub_author = 'Luke Pomfrey'
+epub_publisher = 'Luke Pomfrey'
+epub_copyright = '2013, Luke Pomfrey'
 
 # The language of the text. It defaults to the language option
 # or en if the language is not set.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,8 @@
 import os
 import re
 import sys
-from distutils import version
+
+from packaging import version
 
 
 init_py = open('../debreach/__init__.py').read()
@@ -55,7 +56,7 @@ copyright = u'2013, Luke Pomfrey'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-version = u'{0}'.format(version.StrictVersion(version_string))
+version = u'{0}'.format(version.Version(version_string))
 # The full version, including alpha/beta/rc tags.
 release = version_string
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+minversion = 3.18.0
 envlist = py{39,310,311,312,313}-dj42,py{310,311,312,313}-dj52, docs
 skip_missing_interpreters = True
 isolated_build = True
@@ -13,7 +14,7 @@ deps =
 
 [testenv:docs]
 changedir = docs
-whitelist_externals = make
+allowlist_externals = make
 deps =
     sphinx
 commands = 


### PR DESCRIPTION
Fix the failing `tox -e docs` target.